### PR TITLE
Disable test caching introduced in golang 1.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 swarm:
 	docker service rm stronghash env-test
 test:
-	gateway_url=http://localhost:8080/ time go test ./tests -v
+	gateway_url=http://localhost:8080/ time go test -count=1 ./tests -v


### PR DESCRIPTION
According to https://golang.org/doc/go1.10#test the idomatic way to
disable test caching is to add `-count=1` as a commandline argument.

The reason to disable caching is that if the target gateway image is
changed for testing purposes and you have already ran the make file
once, the tests won't run again until you change the source in this
repoistory.

Signed-off-by: Edward Wilde <ewilde@gmail.com>