### PR TITLE
Add flag to stop tests from caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 swarm:
 	docker service rm stronghash env-test
 test:
-	gateway_url=http://localhost:8080/ time go test ./tests -v
+	gateway_url=http://localhost:8080/ time go test ./tests -v -count=1


### PR DESCRIPTION
As these are integration tests, it doesn't make sense to ever cache
them.

Signed-off-by: Edward Wilde <ewilde@gmail.com>