### PR TITLE
Add test for secrets

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,10 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
+<<<<<<< HEAD
   inputs-digest = "10022891ee70103c2c36e92b53426baec813bdbe484ff3836908afaf8ec82f10"
+=======
+  inputs-digest = "36e066f2021c784556e9c3cf28aa173d05f5a90a52c24939feecce55c0b87144"
+>>>>>>> Add test for secrets
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
 OPENFAAS_URL?=http://127.0.0.1:8080/
 
 swarm:
-	docker service rm stronghash env-test env-test-labels env-test-annotations
+	docker service rm stronghash env-test env-test-labels env-test-annotations test-secret
 kubernetes:
 	kubectl delete -n openfaas-fn deploy/stronghash ; kubectl delete -n openfaas-fn deploy/env-test
 	kubectl delete -n openfaas-fn env-test-labels ; kubectl delete -n openfaas-fn env-test-annotations
-test:
+	kubectl delete -n openfaas-fn deploy/test-secret
+
+SECRET?=tDsdf7sFT45gs8D3gDGhg54
+
+.EXPORT_ALL_VARIABLES:
+secrets:
+	./create-swarm-secret.sh
+	./create-kubernetes-secret.sh
+test: secrets
 	gateway_url=${OPENFAAS_URL} time go test -count=1 ./tests -v

--- a/create-kubernetes-secret.sh
+++ b/create-kubernetes-secret.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [[ $(kubectl get secrets -n openfaas-fn | grep secret-api-test-key | wc -l) -eq 0 ]]
+then
+    echo $SECRET | kubectl create secret generic secret-api-test-key --namespace openfaas-fn
+    echo "Kubernetes secret created"
+else
+    echo "Kubernetes secret already exists. Removing old secret secret-api-test-key form openfaas-fn"
+    kubectl delete secret secret-api-test-key -n openfaas-fn
+    echo $SECRET | kubectl create secret generic secret-api-test-key --namespace openfaas-fn
+    echo "Kubernetes secret created"
+fi 

--- a/create-swarm-secret.sh
+++ b/create-swarm-secret.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [[ $(docker secret ls | grep secret-api-test-key | wc -l) -eq 0 ]]
+then
+    echo $SECRET | docker secret create secret-api-test-key -
+    echo "Swarm secret created"
+else
+    echo "Swarm secret already exists. Removing old secret secret-api-test-key"
+    docker secret rm secret-api-test-key
+    echo $SECRET | docker secret create secret-api-test-key -
+    echo "Swarm secret created"
+fi 


### PR DESCRIPTION
This change adds a test for Swarm and Kubernetes secrets being
accessible/readable from functions. Requires pre-run of
`make secrets`

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

Resolves #7 

### How has this been tested:

1. `make secrets` was tested several times  to verify it can re-run correctly

2. `make test` output:
```
=== RUN   Test_Access_Secret
=== RUN   Test_Access_Secret/Empty_QueryString
--- PASS: Test_Access_Secret (9.14s)
    --- PASS: Test_Access_Secret/Empty_QueryString (9.12s)
    	deploy_test.go:154: [1/30] Bad response want: [200], got: 502
    	deploy_test.go:155: http://127.0.0.1:8080/function/test-secret
    	deploy_test.go:154: [2/30] Bad response want: [200], got: 502
    	deploy_test.go:155: http://127.0.0.1:8080/function/test-secret
    	deploy_test.go:154: [3/30] Bad response want: [200], got: 502
    	deploy_test.go:155: http://127.0.0.1:8080/function/test-secret
    	deploy_test.go:154: [4/30] Bad response want: [200], got: 502
    	deploy_test.go:155: http://127.0.0.1:8080/function/test-secret
    	deploy_test.go:163: [5/30] Correct response: 200
```
