### PR TITLE
Adds test for health check endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ clean-kubernetes:
 	- kubectl delete -n openfaas-fn deploy/stronghash || : ; kubectl delete -n openfaas-fn svc/stronghash || :
 	- kubectl delete -n openfaas-fn deploy/env-test || :; kubectl delete -n openfaas-fn svc/env-test || :
 	- kubectl delete -n openfaas-fn deploy/env-test-annotations || : ; kubectl delete -n openfaas-fn svc/env-test-annotations || :
+	- kubectl delete -n openfaas-fn deploy/env-test-labels || : ; kubectl delete -n openfaas-fn svc/env-test-labels || :
 	- kubectl delete -n openfaas-fn deploy/env-test-verbs  || :; kubectl delete -n openfaas-fn svc/env-test-verbs || :
 	- kubectl delete -n openfaas-fn deploy/test-secret  || :; kubectl delete -n openfaas-fn svc/test-secret || :
 

--- a/tests/health_test.go
+++ b/tests/health_test.go
@@ -1,0 +1,20 @@
+package tests
+
+import (
+	"net/http"
+	"os"
+	"testing"
+)
+
+func Test_HealthEndpoint(t *testing.T) {
+	_, res, err := httpReq(os.Getenv("gateway_url")+"/healthz", http.MethodGet, nil)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Logf("got %d, wanted %d", res.StatusCode, http.StatusOK)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Test output:

**Docker swarm**
```
make test-swarm                                        Fri  3 May 13:49:07 2019
docker service rm stronghash env-test env-test-labels env-test-annotations env-test-verbs test-secret ; docker secret rm secret-api-test-key
Error: No such service: stronghash
Error: No such service: env-test
Error: No such service: env-test-labels
Error: No such service: env-test-annotations
Error: No such service: env-test-verbs
Error: No such service: test-secret
secret-api-test-key
./create-swarm-secret.sh
iiur60ocxlmgf4wgmtlywd5fn
Swarm secret created
gateway_url=http://127.0.0.1:8080/ time go test -count=1 ./tests -v
=== RUN   Test_Access_Secret
=== RUN   Test_Access_Secret/Empty_QueryString
--- PASS: Test_Access_Secret (7.93s)
    --- PASS: Test_Access_Secret/Empty_QueryString (7.91s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/test-secret
=== RUN   Test_Deploy_Stronghash
--- PASS: Test_Deploy_Stronghash (0.01s)
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString/Empty_QueryString
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString/Populated_QueryString
--- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString (7.31s)
    --- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString/Empty_QueryString (7.30s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test
    --- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString/Populated_QueryString (0.00s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test?testing=1
=== RUN   Test_Deploy_WithLabels
--- PASS: Test_Deploy_WithLabels (6.85s)
    verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-labels
=== RUN   Test_Deploy_WithAnnotations
--- PASS: Test_Deploy_WithAnnotations (6.74s)
    verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-annotations
=== RUN   Test_HealthEndpoint
--- PASS: Test_HealthEndpoint (0.00s)
=== RUN   Test_InvokeNotFound
--- PASS: Test_InvokeNotFound (0.00s)
    verify.go:71: [1/30] Got correct response: 404 - http://127.0.0.1:8080/function/notfound
=== RUN   Test_Invoke_With_Supported_Verbs
=== RUN   Test_Invoke_With_Supported_Verbs/GET
=== RUN   Test_Invoke_With_Supported_Verbs/POST
=== RUN   Test_Invoke_With_Supported_Verbs/PUT
=== RUN   Test_Invoke_With_Supported_Verbs/PATCH
=== RUN   Test_Invoke_With_Supported_Verbs/DELETE
--- PASS: Test_Invoke_With_Supported_Verbs (6.87s)
    --- PASS: Test_Invoke_With_Supported_Verbs/GET (6.85s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/POST (0.00s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/PUT (0.00s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/PATCH (0.00s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/DELETE (0.00s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:8080/function/env-test-verbs
PASS
ok  	github.com/openfaas/certifier/tests	35.728s
       36.33 real         0.76 user         0.49 sys
```

Process finished with exit code 0


**Kubernetes output**

```
make test-kubernetes                         1.5m  Fri  3 May 13:38:57 2019
./create-kubernetes-secret.sh
secret "secret-api-test-key" deleted
secret/secret-api-test-key created
kubectl delete -n openfaas-fn deploy/stronghash || : ; kubectl delete -n openfaas-fn svc/stronghash || :
deployment.extensions "stronghash" deleted
service "stronghash" deleted
kubectl delete -n openfaas-fn deploy/env-test || :; kubectl delete -n openfaas-fn svc/env-test || :
deployment.extensions "env-test" deleted
service "env-test" deleted
kubectl delete -n openfaas-fn deploy/env-test-annotations || : ; kubectl delete -n openfaas-fn svc/env-test-annotations || :
deployment.extensions "env-test-annotations" deleted
service "env-test-annotations" deleted
kubectl delete -n openfaas-fn deploy/env-test-labels || : ; kubectl delete -n openfaas-fn svc/env-test-labels || :
deployment.extensions "env-test-labels" deleted
service "env-test-labels" deleted
kubectl delete -n openfaas-fn deploy/env-test-verbs  || :; kubectl delete -n openfaas-fn svc/env-test-verbs || :
deployment.extensions "env-test-verbs" deleted
service "env-test-verbs" deleted
kubectl delete -n openfaas-fn deploy/test-secret  || :; kubectl delete -n openfaas-fn svc/test-secret || :
deployment.extensions "test-secret" deleted
service "test-secret" deleted
gateway_url=http://127.0.0.1:31112/ time go test -count=1 ./tests -v
=== RUN   Test_Access_Secret
=== RUN   Test_Access_Secret/Empty_QueryString
--- PASS: Test_Access_Secret (17.16s)
    --- PASS: Test_Access_Secret/Empty_QueryString (17.12s)
        verify.go:52: [1/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/test-secret
        verify.go:52: [2/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/test-secret
        verify.go:52: [3/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/test-secret
        verify.go:52: [4/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/test-secret
        verify.go:71: [5/30] Got correct response: 200 - http://127.0.0.1:31112/function/test-secret
=== RUN   Test_Deploy_Stronghash
--- PASS: Test_Deploy_Stronghash (0.04s)
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString/Empty_QueryString
=== RUN   Test_Deploy_PassingCustomEnvVars_AndQueryString/Populated_QueryString
--- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString (14.12s)
    --- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString/Empty_QueryString (14.07s)
        verify.go:52: [1/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/env-test
        verify.go:52: [2/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/env-test
        verify.go:52: [3/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/env-test
        verify.go:71: [4/30] Got correct response: 200 - http://127.0.0.1:31112/function/env-test
    --- PASS: Test_Deploy_PassingCustomEnvVars_AndQueryString/Populated_QueryString (0.00s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:31112/function/env-test?testing=1
=== RUN   Test_Deploy_WithLabels
--- PASS: Test_Deploy_WithLabels (13.10s)
    verify.go:52: [1/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/env-test-labels
    verify.go:52: [2/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/env-test-labels
    verify.go:52: [3/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/env-test-labels
    verify.go:71: [4/30] Got correct response: 200 - http://127.0.0.1:31112/function/env-test-labels
=== RUN   Test_Deploy_WithAnnotations
--- PASS: Test_Deploy_WithAnnotations (8.09s)
    verify.go:52: [1/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/env-test-annotations
    verify.go:52: [2/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/env-test-annotations
    verify.go:71: [3/30] Got correct response: 200 - http://127.0.0.1:31112/function/env-test-annotations
=== RUN   Test_HealthEndpoint
--- PASS: Test_HealthEndpoint (0.00s)
=== RUN   Test_InvokeNotFound
--- PASS: Test_InvokeNotFound (0.00s)
    verify.go:71: [1/30] Got correct response: 502 - http://127.0.0.1:31112/function/notfound
=== RUN   Test_Invoke_With_Supported_Verbs
=== RUN   Test_Invoke_With_Supported_Verbs/GET
=== RUN   Test_Invoke_With_Supported_Verbs/POST
=== RUN   Test_Invoke_With_Supported_Verbs/PUT
=== RUN   Test_Invoke_With_Supported_Verbs/PATCH
=== RUN   Test_Invoke_With_Supported_Verbs/DELETE
--- PASS: Test_Invoke_With_Supported_Verbs (6.10s)
    --- PASS: Test_Invoke_With_Supported_Verbs/GET (6.05s)
        verify.go:52: [1/30] Bad response want: [200], got: 502 - http://127.0.0.1:31112/function/env-test-verbs
        verify.go:71: [2/30] Got correct response: 200 - http://127.0.0.1:31112/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/POST (0.00s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:31112/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/PUT (0.00s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:31112/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/PATCH (0.00s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:31112/function/env-test-verbs
    --- PASS: Test_Invoke_With_Supported_Verbs/DELETE (0.00s)
        verify.go:71: [1/30] Got correct response: 200 - http://127.0.0.1:31112/function/env-test-verbs
PASS
ok  	github.com/openfaas/certifier/tests	58.635s
       59.29 real         0.82 user         0.55 sys
```