### PR TITLE
Write secret CRUD tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ OPENFAAS_URL?=http://127.0.0.1:8080/
 SECRET?=tDsdf7sFT45gs8D3gDGhg54
 
 clean-swarm:
-	-  docker service rm stronghash env-test env-test-labels env-test-annotations env-test-verbs test-secret ; docker secret rm secret-api-test-key 
+	-  docker service rm stronghash env-test env-test-labels env-test-annotations env-test-verbs test-secret test-secret-crud; docker secret rm secret-api-test-key 
 
 clean-kubernetes:
 	- kubectl delete -n openfaas-fn deploy/stronghash || : ; kubectl delete -n openfaas-fn svc/stronghash || :
@@ -11,6 +11,7 @@ clean-kubernetes:
 	- kubectl delete -n openfaas-fn deploy/env-test-labels || : ; kubectl delete -n openfaas-fn svc/env-test-labels || :
 	- kubectl delete -n openfaas-fn deploy/env-test-verbs  || :; kubectl delete -n openfaas-fn svc/env-test-verbs || :
 	- kubectl delete -n openfaas-fn deploy/test-secret  || :; kubectl delete -n openfaas-fn svc/test-secret || :
+	- kubectl delete -n openfaas-fn deploy/test-secret-crud  || :; kubectl delete -n openfaas-fn svc/test-secret-crud || :
 
 .EXPORT_ALL_VARIABLES:
 secrets-swarm:
@@ -20,7 +21,7 @@ secrets-kubernetes:
 	./create-kubernetes-secret.sh
 
 test-swarm: clean-swarm secrets-swarm 
-	gateway_url=${OPENFAAS_URL} time go test -count=1 ./tests -v
+	gateway_url=${OPENFAAS_URL} time go test -count=1 ./tests -v -swarm
 
 test-kubernetes: secrets-kubernetes clean-kubernetes
 	gateway_url=${OPENFAAS_URL} time go test -count=1 ./tests -v

--- a/tests/secretCRUD_test.go
+++ b/tests/secretCRUD_test.go
@@ -1,0 +1,186 @@
+package tests
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/openfaas/faas-provider/types"
+	"github.com/openfaas/faas/gateway/requests"
+)
+
+var secretsURL string = os.Getenv("gateway_url") + "system/secrets"
+var swarm = flag.Bool("swarm", false, "run swarm-compatible tests only")
+
+type secret types.Secret
+
+func Test_SecretCRUD(t *testing.T) {
+	setValue := "this-is-the-secret-value"
+	setName := "secret-name"
+	functionName := "test-secret-crud"
+
+	createStatus, err := createSecret(setName, setValue)
+	if err != nil {
+		t.Error(err)
+	}
+	if createStatus != http.StatusCreated && createStatus != http.StatusAccepted {
+		t.Errorf("got %d, wanted %d or %d", createStatus, http.StatusOK, http.StatusAccepted)
+	}
+	t.Logf("Got correct response for creating secret: %d", createStatus)
+
+	// Set up and deploy function that reads the value of the created secret.
+	functionRequest := requests.CreateFunctionRequest{
+		Image:      "functions/alpine:latest",
+		Service:    functionName,
+		Network:    "func_functions",
+		EnvProcess: "cat /var/openfaas/secrets/" + setName,
+		Secrets:    []string{setName},
+	}
+	deployStatus, err := deploy(t, functionRequest)
+	if err != nil {
+		t.Error(err)
+	}
+	if deployStatus != http.StatusOK && deployStatus != http.StatusAccepted {
+		t.Errorf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
+	}
+	t.Logf("Got correct response for deploying function: %d", deployStatus)
+
+	// Verify that the secret value was set as intended.
+	value := string(invoke(t, functionRequest.Service, "", http.StatusOK))
+	if value != setValue {
+		t.Errorf("got %s, wanted %s", value, setValue)
+	}
+
+	// Verify that the secret can be listed.
+	names, listStatus, err := listSecrets()
+	if err != nil {
+		t.Error(err)
+	}
+	if !listContains(names, setName) {
+		t.Errorf("got %v, wanted %s in slice", names, setName)
+	}
+	t.Logf("Got correct response for listing secrets: %d", listStatus)
+
+	// Docker Swarm secrets are immutable, so skip the update tests for swarm.
+	if !*swarm {
+		newValue := "this-is-the-edited-secret-value"
+		updateStatus, err := updateSecret(setName, newValue)
+		if err != nil {
+			t.Error(err)
+		}
+		if updateStatus != http.StatusOK && updateStatus != http.StatusAccepted {
+			t.Errorf("got %d, wanted %d or %d", updateStatus, http.StatusOK, http.StatusAccepted)
+		}
+		t.Logf("Got correct response for updating secret: %d", updateStatus)
+
+		// Verify that the secret value was edited.
+		value = string(invoke(t, functionRequest.Service, "", http.StatusOK))
+		if value != setValue {
+			t.Errorf("got %s, wanted %s", value, newValue)
+		}
+	}
+
+	// Function needs to be deleted to free up the secret so it can also be deleted.
+	delFunctionRequest := requests.DeleteFunctionRequest{
+		FunctionName: functionName,
+	}
+	delFunctionStatus, err := delete(t, delFunctionRequest)
+	if err != nil {
+		t.Error(err)
+	}
+	if delFunctionStatus != http.StatusOK && delFunctionStatus != http.StatusAccepted {
+		t.Errorf("got %d, wanted %d or %d", delFunctionStatus, http.StatusOK, http.StatusAccepted)
+	}
+	t.Logf("Got correct response for deleting function: %d", delFunctionStatus)
+
+	deleteStatus, err := deleteSecret(setName)
+	if err != nil {
+		t.Error(err)
+	}
+	if deleteStatus != http.StatusOK && deleteStatus != http.StatusAccepted {
+		t.Errorf("got %d, wanted %d or %d", deleteStatus, http.StatusOK, http.StatusAccepted)
+	}
+	t.Logf("Got correct response for deleting secret: %d", deleteStatus)
+
+	// Verify that the secret was deleted.
+	names, listStatus, err = listSecrets()
+	if err != nil {
+		t.Error(err)
+	}
+	if listContains(names, setName) {
+		t.Errorf("got %v, wanted %s deleted", names, setName)
+	}
+	t.Logf("Got correct response for listing secret: %d", listStatus)
+}
+
+func createSecret(name, value string) (int, error) {
+	req := secret{
+		Name:  name,
+		Value: value,
+	}
+	rdr := makeReader(req)
+
+	_, res, err := httpReq(secretsURL, http.MethodPost, rdr)
+	return res.StatusCode, err
+}
+
+func updateSecret(name, edit string) (int, error) {
+	req := secret{
+		Name:  name,
+		Value: edit,
+	}
+	rdr := makeReader(req)
+
+	_, res, err := httpReq(secretsURL, http.MethodPut, rdr)
+	return res.StatusCode, err
+}
+
+func deleteSecret(name string) (int, error) {
+	req := secret{Name: name}
+	rdr := makeReader(req)
+
+	_, res, err := httpReq(secretsURL, http.MethodDelete, rdr)
+
+	if err != nil {
+		return 0, err
+	}
+	return res.StatusCode, nil
+}
+
+func listContains(list []secret, s string) bool {
+	for i := range list {
+		if list[i].Name == s {
+			return true
+		}
+	}
+	return false
+}
+
+func listSecrets() ([]secret, int, error) {
+	secretsList := []secret{}
+
+	secrets, res, err := httpReq(secretsURL, http.MethodGet, nil)
+	if err != nil {
+		return secretsList, res.StatusCode, err
+	}
+
+	json.Unmarshal(secrets, &secretsList)
+	return secretsList, res.StatusCode, nil
+}
+
+func delete(t *testing.T, delFunctionRequest requests.DeleteFunctionRequest) (int, error) {
+	body, res, err := httpReq(os.Getenv("gateway_url")+"system/functions", http.MethodDelete, makeReader(delFunctionRequest))
+
+	if err != nil {
+		return http.StatusBadGateway, err
+	}
+
+	if res.StatusCode >= 400 {
+		t.Logf("Delete response: %s", string(body))
+		return res.StatusCode, fmt.Errorf("unable to delete function")
+	}
+	return res.StatusCode, nil
+}


### PR DESCRIPTION
Signed-off-by: Frankie Gold <fgold@vmware.com>

**Description**

Add testing the secrets CRUD API per guidelines provided by @alexellis in #16. Modified the Makefile as needed.

**Motivation and Context**

Refer to issue #16.

Ensure creating, retrieving, updating, and deleting secrets via the API works as intended.

**How Has This Been Tested?**
- [X] Tested with Kubernetes on a single-node cluster (`make test-kubernetes`) 
- [X] Tested with Docker Swarm (`make test-swarm`)
- [X] Tested with OpenFaaS operator (I used `make test-kubernetes` and the tests passed)
