### PR TITLE
Add support to run e2e test on docker swarm and kubernetes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,23 @@ language: go
 
 go:
   - 1.8.x
-  
+
+before_install:
+  - sudo apt-get update && sudo apt-get install -y apt-transport-https
+  - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+  - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+  - sudo apt-get update
+  - sudo apt-get install -y kubectl 
+
+addons:
+  apt:
+    packages:
+      - docker-ce
+    
 install:
   - echo "Please don't go get"
 
 script:
   - find .
+  - bash run-e2e-test-docker-swarm.sh
+  - bash run-e2e-test-k8s.sh

--- a/run-e2e-test-docker-swarm.sh
+++ b/run-e2e-test-docker-swarm.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if ! [ -x "$(command -v docker)" ]; then
+  echo 'Unable to find docker command, please install Docker (https://www.docker.com/) and retry' >&2
+  exit 1
+fi
+
+export IP=127.0.0.1
+# setup docker swarm 
+docker swarm init
+git clone https://github.com/openfaas/faas.git
+cd faas && echo "$(pwd)" && ./deploy_stack.sh --no-auth && cd ..
+
+# run test in docker swarm
+export OPENFAAS_URL=http://$IP:8080/
+sleep 60
+make -i test-swarm
+
+# remove docker swarm, once tests complete
+docker swarm leave --force

--- a/run-e2e-test-k8s.sh
+++ b/run-e2e-test-k8s.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+if ! [ -x "$(command -v docker)" ]; then
+  echo 'Unable to find docker command, please install Docker (https://www.docker.com/) and retry' >&2
+  exit 1
+fi
+
+export IP=127.0.0.1
+export USER_NAME=$(whoami)
+export KUBECONFIG_FOLDER_PATH=/home/$USER_NAME/.kube
+export KUBECONFIG_PATH=$KUBECONFIG_FOLDER_PATH/config
+
+# setup k3s using k3sup
+sudo curl -sLS https://get.k3sup.dev | sh
+sudo install k3sup /usr/local/bin/
+mkdir -p $KUBECONFIG_FOLDER_PATH
+k3sup install --local --ip $IP --user $USER_NAME
+cp `pwd`/kubeconfig $KUBECONFIG_PATH
+export KUBECONFIG=$KUBECONFIG_PATH
+
+# disable basic auth
+k3sup app install openfaas --basic-auth=false
+
+# run test in k3s
+sleep 60
+export OPENFAAS_URL=http://$IP:31112/
+make -i test-kubernetes


### PR DESCRIPTION
Add support to run e2e test on docker swarm and kubernetes

we will be able to run the test on both docker and k8, before
any new changes are being merged to the project. This way we
will be able to ensure that all changes are compatible with
both environment. This PR closes #25.