### PR TITLE
WIP Streamline tests statements and use helpers

### DIFF
--- a/tests/health_test.go
+++ b/tests/health_test.go
@@ -2,29 +2,13 @@ package tests
 
 import (
 	"net/http"
-	"net/url"
-	"os"
 	"testing"
 )
 
 func Test_HealthEndpoint(t *testing.T) {
-
-	gwURL, urlErr := url.Parse(os.Getenv("gateway_url"))
-
-	if urlErr != nil {
-		t.Fatal(urlErr)
-	}
-
-	gwURL.Path = "/healthz"
-
-	_, res, err := httpReq(gwURL.String(), http.MethodGet, nil)
-	if err != nil {
-		t.Log(err)
-		t.Fail()
-	}
-
+	gwURL := gatewayUrl(t, "healthz", "")
+	_, res := request(t, gwURL, http.MethodGet, nil)
 	if res.StatusCode != http.StatusOK {
-		t.Logf("error with /healthz, got %d, but want %d", res.StatusCode, http.StatusOK)
-		t.Fail()
+		t.Fatalf("error with /healthz, got %d, but want %d", res.StatusCode, http.StatusOK)
 	}
 }

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_InvokeNotFound(t *testing.T) {
-	invoke(t, "notfound", emptyQueryString, http.StatusNotFound, http.StatusBadGateway)
+	_ = invoke(t, "notfound", emptyQueryString, http.StatusNotFound, http.StatusBadGateway)
 }
 
 func Test_Invoke_With_Supported_Verbs(t *testing.T) {
@@ -24,16 +24,9 @@ func Test_Invoke_With_Supported_Verbs(t *testing.T) {
 		EnvVars:    envVars,
 	}
 
-	deployStatus, deployErr := deploy(t, functionRequest)
-	if deployErr != nil {
-		t.Log(deployErr.Error())
-		t.Fail()
-		return
-	}
-
+	deployStatus := deploy(t, functionRequest)
 	if deployStatus != http.StatusOK && deployStatus != http.StatusAccepted {
-		t.Logf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
-		t.Fail()
+		t.Fatalf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
 		return
 	}
 
@@ -56,8 +49,7 @@ func Test_Invoke_With_Supported_Verbs(t *testing.T) {
 
 			out := string(bytesOut)
 			if !v.match(out) {
-				t.Logf("want: %s, got: %s", fmt.Sprintf("Http_Method=%s", v.verb), out)
-				t.Fail()
+				t.Fatalf("want: %s, got: %s", fmt.Sprintf("Http_Method=%s", v.verb), out)
 			}
 		})
 	}


### PR DESCRIPTION
**What**
- Convert deploy into a test helper. It will call fatal if the requests
  returns a failure, reducing a lot of the boilerplate in the actual
  tests
- Similarly, convert many of the `t.Log` followed by `t.Fail` to
  `t.Fatal`. This change is almost exactly the same behavior, except
  that the tests will now stop at those points. Calling Fail does not
  actually stop the test and in almost every case the subsequent code
  depends on success, hence it makes sense to use `Fatal` instead of
  the original `Fail`. In general, it is better to `defer` cleanup tasks that
  _must_ be run even after a failure
- Also in the same theme, create a new `request` test helper that
  behaves the same as `httpReq`, except that it accepts and will fail
  the test `t` if there is an error during the request or while reading
  the request body. The `httpReq` was removed, because it is not
  otherwise being used

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>