### PR TITLE
Create load and replica watch helpers

### DIFF
--- a/tests/scaling_test.go
+++ b/tests/scaling_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -94,38 +95,40 @@ func Test_ScaleUpAndDownFromThroughPut(t *testing.T) {
 
 	defer deleteFunction(t, functionName)
 
-	functionURL := resourceURL(t, path.Join("function", functionName), "")
-	req, err := http.NewRequest(http.MethodPost, functionURL, nil)
-	if err != nil {
-		t.Fatalf("error with request %s ", err)
-	}
-
-	var loadOutput bytes.Buffer
 	attempts := 1000
-	functionLoad := requester.Work{
-		Request:           req,
-		N:                 attempts,
-		Timeout:           10,
-		C:                 2,
-		QPS:               5.0,
-		DisableKeepAlives: true,
-		Writer:            &loadOutput,
+	output, cancelLoad := sendRequestLoad(t, functionName, attempts)
+	replicas, cancelWatch := watchReplicaCount(t, functionName, maxReplicas)
+
+	var loadOutput string
+	var foundReplicas uint64
+	select {
+	case loadOutput = <-output:
+		// end of load
+		cancelLoad()
+		cancelWatch()
+		t.Log("request load finished")
+	case foundReplicas = <-replicas:
+		// reached desired replica count
+		cancelLoad()
+		cancelWatch()
 	}
 
-	functionLoad.Init()
-	functionLoad.Run()
-
-	fnc := get(t, functionName)
-	if fnc.Replicas != maxReplicas {
-		t.Logf("function load output %s", loadOutput.String())
-		t.Fatalf("never reached max scale %d, only %d replicas after %d attempts", maxReplicas, fnc.Replicas, attempts)
+	if foundReplicas != maxReplicas {
+		t.Logf("function load output %s", loadOutput)
+		t.Fatalf("never reached max scale %d, only %d replicas after %d attempts", maxReplicas, foundReplicas, attempts)
 	}
 
-	// cooldown
-	time.Sleep(time.Minute)
-	fnc = get(t, functionName)
-	if fnc.Replicas != minReplicas {
-		t.Fatalf("got %d replicas, wanted %d", fnc.Replicas, minReplicas)
+	replicas, cancelWatch = watchReplicaCount(t, functionName, minReplicas)
+	defer cancelWatch()
+
+	select {
+	case <-replicas:
+		return
+	case <-time.After(65 * time.Second):
+		fnc := get(t, functionName)
+		if fnc.AvailableReplicas != minReplicas {
+			t.Fatalf("got %d replicas, wanted %d", fnc.Replicas, minReplicas)
+		}
 	}
 }
 
@@ -176,8 +179,11 @@ func Test_ScalingDisabledViaLabels(t *testing.T) {
 	functionLoad.Init()
 	functionLoad.Run()
 
+	// don't use watchReplicaCount here because the function starts and should stay at the
+	// same replica count throughout the entire load, here we want to just run through the entire
+	// and check the replica count at the end
 	fnc := get(t, functionName)
-	if fnc.Replicas != minReplicas {
+	if fnc.AvailableReplicas != minReplicas {
 		t.Logf("function load output %s", loadOutput.String())
 		t.Fatalf("unexpected scaling, expected %d, got %d replicas after %d attempts", minReplicas, fnc.Replicas, attempts)
 	}
@@ -220,17 +226,60 @@ func Test_ScaleToZero(t *testing.T) {
 
 	defer deleteFunction(t, functionName)
 
+	attempts := 1000
+	output, cancelLoad := sendRequestLoad(t, functionName, attempts)
+	replicas, cancelWatch := watchReplicaCount(t, functionName, maxReplicas)
+
+	var loadOutput string
+	var foundReplicas uint64
+	select {
+	case loadOutput = <-output:
+		// end of load
+		cancelLoad()
+		cancelWatch()
+		t.Log("request load finished")
+	case foundReplicas = <-replicas:
+		// reached desired replica count
+		cancelLoad()
+		cancelWatch()
+	}
+
+	if foundReplicas != maxReplicas {
+		t.Logf("function load output %s", loadOutput)
+		t.Fatalf("never reached max scale %d, only %d replicas after %d attempts", maxReplicas, foundReplicas, attempts)
+	}
+
+	// cooldown
+	replicas, cancelWatch = watchReplicaCount(t, functionName, 0)
+	defer cancelWatch()
+
+	select {
+	case <-replicas:
+		return
+	case <-time.After(65 * time.Second):
+		fnc := get(t, functionName)
+		if fnc.AvailableReplicas != 0 {
+			t.Fatalf("got %d replicas, wanted %d", fnc.Replicas, 0)
+		}
+	}
+}
+
+// sendRequestLoad is a helper method that will construct and run the hey Worker in a separate
+// goroutine. When the worker finished, the output will be sent over the channel.  The caller
+// can use the cancel method to stop the worker early
+func sendRequestLoad(t *testing.T, functionName string, loadAttempts int) (_ <-chan string, cancel func()) {
+	results := make(chan string)
+
 	functionURL := resourceURL(t, path.Join("function", functionName), "")
 	req, err := http.NewRequest(http.MethodPost, functionURL, nil)
 	if err != nil {
-		t.Fatalf("error with request %s ", err)
+		t.Fatalf("error building function load request %s ", err)
 	}
 
 	var loadOutput bytes.Buffer
-	attempts := 1000
 	functionLoad := requester.Work{
 		Request:           req,
-		N:                 attempts,
+		N:                 loadAttempts,
 		Timeout:           10,
 		C:                 2,
 		QPS:               5.0,
@@ -238,19 +287,45 @@ func Test_ScaleToZero(t *testing.T) {
 		Writer:            &loadOutput,
 	}
 
-	functionLoad.Init()
-	functionLoad.Run()
+	go func() {
+		functionLoad.Init()
+		functionLoad.Run()
 
-	fnc := get(t, functionName)
-	if fnc.Replicas != maxReplicas {
-		t.Logf("function load output %s", loadOutput.String())
-		t.Fatalf("never reached max scale %d, only %d replicas after %d attempts", maxReplicas, fnc.Replicas, attempts)
-	}
+		results <- loadOutput.String()
+		close(results)
+	}()
 
-	// cooldown
-	time.Sleep(2 * time.Minute)
-	fnc = get(t, functionName)
-	if fnc.Replicas != 0 {
-		t.Fatalf("got %d replicas, wanted 0", fnc.Replicas)
-	}
+	return results, functionLoad.Stop
+}
+
+// watchReplicaCount is helper method what will use the OpenFaaS API to watch and wait for a
+// function to reach a desired available replica count. Once reached, the count is sent
+// over the result channel. The caller can use the cancel method to stop the replica watcher early.
+func watchReplicaCount(t *testing.T, functionName string, target uint64) (_ <-chan uint64, cancel func()) {
+	t.Helper()
+	results := make(chan uint64)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func(t *testing.T) {
+		defer close(results)
+		start := time.Now()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				fnc := get(t, functionName)
+				if fnc.AvailableReplicas == target {
+					t.Logf("reached desired replicas '%d' in %s", target, time.Since(start))
+					results <- fnc.AvailableReplicas
+					return
+				}
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+	}(t)
+
+	return results, cancel
 }


### PR DESCRIPTION
**What**
- Create helper methods for generating load and for watching the replica
  count. This allows us to also time how long it takes for the system to
  reach the desired replica counts.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>