### PR TITLE
Verify that redirect responses are propagated during invoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+functions/build
+functions/template

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,20 @@ OPENFAAS_URL?=http://127.0.0.1:8080/
 
 GOFLAGS := -mod=vendor
 
-.TEST_FUNCTIONS = stronghash env-test env-test-annotations env-test-labels env-test-verbs test-secret-crud test-min-scale test-scale-from-zero test-throughput-scaling test-scaling-disabled test-scaling-to-zero test-logger
+.TEST_FUNCTIONS = \
+	stronghash \
+	env-test \
+	env-test-annotations \
+	env-test-labels \
+	env-test-verbs \
+	test-secret-crud \
+	test-min-scale \
+	test-scale-from-zero \
+	test-throughput-scaling \
+	test-scaling-disabled \
+	test-scaling-to-zero \
+	test-logger \
+	redirector-test
 
 clean-swarm:
 	- docker service rm ${.TEST_FUNCTIONS}

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ While developing the `certifier`, we generally run/test the `certifier` locally 
 ```sh
 kind create cluster
 arkade install openfaas --basic-auth=false
-kubectl port-forward -n openfaas svc/gateway 8080:8080  > /dev/null 2>&1 &
 kubectl rollout status -n openfaas deploy/gateway
+kubectl port-forward -n openfaas svc/gateway 8080:8080  > /dev/null 2>&1 &
 
 export OPENFAAS_URL=http://127.0.0.1:8080/
 make test-kubernetes

--- a/functions/redirector/handler.go
+++ b/functions/redirector/handler.go
@@ -1,0 +1,17 @@
+package function
+
+import (
+	"net/http"
+	"os"
+)
+
+const defaultDestination = "https://google.com"
+
+func Handle(w http.ResponseWriter, r *http.Request) {
+	destination := os.Getenv("destination")
+	if destination == "" {
+		destination = defaultDestination
+	}
+
+	http.Redirect(w, r, destination, http.StatusFound)
+}

--- a/functions/stack.yml
+++ b/functions/stack.yml
@@ -1,0 +1,16 @@
+version: 1.0
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+
+configuration:
+  templates:
+    - name: golang-middleware
+      source: https://github.com/openfaas-incubator/golang-http-template
+
+functions:
+  redirector:
+    lang: golang-middleware
+    handler: ./redirector
+    image: theaxer/redirector:latest
+

--- a/tests/http.go
+++ b/tests/http.go
@@ -47,7 +47,11 @@ func request(t *testing.T, url, method string, reader io.Reader) ([]byte, *http.
 func requestContext(t *testing.T, ctx context.Context, url, method string, reader io.Reader) ([]byte, *http.Response) {
 	t.Helper()
 
-	c := http.Client{}
+	c := http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 
 	req, makeReqErr := http.NewRequest(method, url, reader)
 	if makeReqErr != nil {

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -54,3 +54,22 @@ func Test_Invoke_With_Supported_Verbs(t *testing.T) {
 		})
 	}
 }
+
+func Test_InvokePropogatesRedirectToTheCaller(t *testing.T) {
+	destination := "http://example.com"
+	functionRequest := types.FunctionDeployment{
+		Image:      "theaxer/redirector:latest",
+		Service:    "redirector-test",
+		Network:    "func_functions",
+		EnvProcess: "./handler",
+		EnvVars:    map[string]string{"destination": destination},
+	}
+
+	deployStatus := deploy(t, functionRequest)
+	if deployStatus != http.StatusOK && deployStatus != http.StatusAccepted {
+		t.Fatalf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
+		return
+	}
+
+	_ = invoke(t, "redirector-test", emptyQueryString, http.StatusFound)
+}


### PR DESCRIPTION
**What**
- Verify that the provider and services correctly proagate redirect
  responses (301, 302, etc) from the function to the original caller
Resolves #18

# NOTES
this is still in progress and seems to have found an issue because the new test fails with

```sh
7.0.0.1:8080/function/redirector-test
    Test_InvokePropogatesRedirectToTheCaller: invoke_test.go:74: [30/30] Bad response want: [302], got: 200 - http://127.0.0.1:8080/function/redirector-test
    Test_InvokePropogatesRedirectToTheCaller: invoke_test.go:74: Failing after: 30 attempts
    Test_InvokePropogatesRedirectToTheCaller: invoke_test.go:74: invoke failed with:
--- FAIL: Test_InvokePropogatesRedirectToTheCaller (30.73s)
FAIL
FAIL	github.com/openfaas/certifier/tests	31.087s
FAIL
       31.82 real         1.04 user         0.75 sys
```
Showing that faas-netes is not returning the correct 302 response code.
