### PR TITLE
Expand dev flow example to be copy&paste-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ While developing the `certifier`, we generally run/test the `certifier` locally 
 ```sh
 kind create cluster
 arkade install openfaas --basic-auth=false
-kubectl port-forward -n openfaas svc/gateway 8080:8080 &
+kubectl port-forward -n openfaas svc/gateway 8080:8080  > /dev/null 2>&1 &
+kubectl rollout status -n openfaas deploy/gateway
+
 export OPENFAAS_URL=http://127.0.0.1:8080/
 make test-kubernetes
 ```


### PR DESCRIPTION
**What**
- Add output redirects and a rollout status to the development flow bash
  snippet so that the entire block can be safely copy and pasted
  without needing to read it or split it apart.

Resolves additional comments on #47 
