### PR TITLE
Validate Multi-Namespace support

### DIFF
--- a/tests/deploy_test.go
+++ b/tests/deploy_test.go
@@ -1,8 +1,10 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"testing"
 
@@ -118,6 +120,30 @@ func Test_Deploy_WithAnnotations(t *testing.T) {
 	function := get(t, functionRequest.FunctionName)
 	if err := strMapEqual("annotations", *function.Annotations, wantedAnnotations); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func Test_ListNamespaces(t *testing.T) {
+	expectedNamespaces := append(config.Namespaces, config.DefaultNamespace)
+	actualNamespaces, err := config.Client.ListNamespaces(context.Background())
+
+	if err != nil {
+		t.Fatalf("Unable to List OpenFaaS Namespaces: %q", err)
+	}
+
+	expectedLen := len(expectedNamespaces)
+	actualLen := len(actualNamespaces)
+	if expectedLen != actualLen {
+		t.Fatalf("want %d namespace(s),  got %d namespace(s)", expectedLen, actualLen)
+	}
+
+	sort.Strings(expectedNamespaces)
+	sort.Strings(actualNamespaces)
+
+	for i, ns := range expectedNamespaces {
+		if ns != actualNamespaces[i] {
+			t.Fatalf("want namespace: %q , got %q", expectedNamespaces, actualNamespaces)
+		}
 	}
 }
 

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -103,6 +103,9 @@ type Config struct {
 
 	// Namespaces to verfiy OpenFaaS provider
 	Namespaces []string
+
+	// DefaultNamespace for OpenFaas provider
+	DefaultNamespace string
 }
 
 func FromEnv(config *Config) {
@@ -113,5 +116,14 @@ func FromEnv(config *Config) {
 		for index := range config.Namespaces {
 			config.Namespaces[index] = strings.TrimSpace(config.Namespaces[index])
 		}
+	}
+
+	// read CERTIFIER_DEFAULT_NAMESPACE variable, if not apply openfaas-fn
+	defaultNamespace, present := os.LookupEnv("CERTIFIER_DEFAULT_NAMESPACE")
+
+	if present {
+		config.DefaultNamespace = defaultNamespace
+	} else {
+		config.DefaultNamespace = "openfaas-fn"
 	}
 }


### PR DESCRIPTION
Signed-off-by: Nitishkumar Singh <nitishkumarsingh71@gmail.com>

Closes #63  

Testing Steps
1. Create Kind Cluster
`kind create cluster --name fass-pv-test`
2. install openfaas using arkade
`arkade install openfaas --basic-auth=false --clusterrole`
3. Port Forward gateway to 8080
`kubectl port-forward -n openfaas svc/gateway 8080:8080 &`
4. Annotate kubernetes namespace
```
kubectl create namespace staging-fn
kubectl annotate namespace/staging-fn openfaas="1"
kubectl create namespace dev
kubectl annotate namespace/dev openfaas="1"
```
5. Export CERTIFIER_NAMESPACES
`export CERTIFIER_NAMESPACES=staging-fn,dev`
6. Test K8 provider
`make test-kubernetes`
