### PR TITLE
feat: Test multi-namespace log support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ OPENFAAS_URL?=http://127.0.0.1:8080/
 
 GOFLAGS := -mod=vendor
 
-.TEST_FUNCTIONS = \
+TEST_FUNCTIONS = \
 	stronghash \
 	env-test \
 	env-test-annotations \
@@ -17,17 +17,17 @@ GOFLAGS := -mod=vendor
 	test-logger \
 	redirector-test
 
-clean-swarm:
-	- docker service rm ${.TEST_FUNCTIONS}
+TEST_SECRETS = \
+	secret-name
+
+export TEST_FUNCTIONS TEST_SECRETS
+
 
 clean-kubernetes:
-	- kubectl delete -n openfaas-fn deploy,svc ${.TEST_FUNCTIONS} 2>/dev/null || : ;
+	- ./contrib/clean_kubernetes.sh
 
 .TEST_FLAGS= # additional test flags, e.g. -run ^Test_ScaleFromZeroDuringIvoke$
 .FEATURE_FLAGS= # set config feature flags, e.g. -swarm
 
-test-swarm: clean-swarm
-	time go test -count=1 ./tests -v -swarm -gateway=${OPENFAAS_URL} ${.FEATURE_FLAGS} ${.TEST_FLAGS}
-
 test-kubernetes: clean-kubernetes
-	time go test -count=1 ./tests -v -gateway=${OPENFAAS_URL} ${.FEATURE_FLAGS} ${.TEST_FLAGS}
+	CERTIFIER_NAMESPACES=certifier-test time go test -count=1 ./tests -v -gateway=${OPENFAAS_URL} ${.FEATURE_FLAGS} ${.TEST_FLAGS}

--- a/contrib/clean_kubernetes.sh
+++ b/contrib/clean_kubernetes.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+
+
+namespaces="openfaas-fn,$CERTIFIER_NAMESPACES"
+for ns in ${namespaces//,/ }
+do
+    echo "cleaning $ns"
+    for f in $TEST_FUNCTIONS
+    do
+        echo "delete function $f"
+        kubectl delete -n "$ns" deploy,svc "$f"
+    done
+
+    for s in $TEST_SECRETS
+    do
+        echo "deleting secret $s"
+        kubectl delete -n "$ns" secrets "$s"
+    done
+done

--- a/contrib/deploy_openfaas.sh
+++ b/contrib/deploy_openfaas.sh
@@ -12,7 +12,10 @@ mkdir -p $KUBECONFIG_FOLDER_PATH
 cp `pwd`/kubeconfig $KUBECONFIG_PATH
 
 echo ">>> Installing openfaas"
-arkade install openfaas --basic-auth=false
+arkade install openfaas --basic-auth=false --clusterrole
+
+kubectl create namespace certifier-test
+kubectl annotate namespace/certifier-test openfaas="1"
 
 echo ">>> Waiting for helm install to complete."
 kubectl rollout status -n openfaas deploy/gateway -w

--- a/tests/function_helpers_test.go
+++ b/tests/function_helpers_test.go
@@ -54,10 +54,14 @@ func get(t *testing.T, name string) types.FunctionStatus {
 	return function
 }
 
-func deleteFunction(t *testing.T, name string) {
+func deleteFunction(t *testing.T, function *sdk.DeployFunctionSpec) {
 	t.Helper()
 
-	err := config.Client.DeleteFunction(context.Background(), name, defaultNamespace)
+	err := config.Client.DeleteFunction(
+		context.Background(),
+		function.FunctionName,
+		function.Namespace,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/invoke_test.go
+++ b/tests/invoke_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Test_InvokeNotFound(t *testing.T) {
-	_ = invoke(t, "notfound", "", http.StatusNotFound, http.StatusBadGateway)
+	_ = invoke(t, "notfound", "", "", http.StatusNotFound, http.StatusBadGateway)
 }
 
 func Test_Invoke_With_Supported_Verbs(t *testing.T) {
@@ -46,7 +46,7 @@ func Test_Invoke_With_Supported_Verbs(t *testing.T) {
 	for _, v := range verbs {
 		t.Run(v.verb, func(t *testing.T) {
 
-			bytesOut, res := invokeWithVerb(t, v.verb, functionRequest.FunctionName, emptyQueryString, http.StatusOK)
+			bytesOut, res := invokeWithVerb(t, v.verb, functionRequest.FunctionName, emptyQueryString, "", http.StatusOK)
 
 			out := string(bytesOut)
 			if !v.match(out) {
@@ -82,7 +82,7 @@ func Test_InvokePropogatesRedirectToTheCaller(t *testing.T) {
 		return
 	}
 
-	_ = invoke(t, "redirector-test", emptyQueryString, http.StatusFound)
+	_ = invoke(t, "redirector-test", emptyQueryString, "", http.StatusFound)
 }
 
 func Test_Invoke_With_CustomEnvVars_AndQueryString(t *testing.T) {
@@ -105,7 +105,7 @@ func Test_Invoke_With_CustomEnvVars_AndQueryString(t *testing.T) {
 	list(t, http.StatusOK)
 
 	t.Run("Empty QueryString", func(t *testing.T) {
-		bytesOut := invoke(t, functionRequest.FunctionName, emptyQueryString, http.StatusOK)
+		bytesOut := invoke(t, functionRequest.FunctionName, emptyQueryString, "", http.StatusOK)
 		out := string(bytesOut)
 		if strings.Contains(out, "custom_env") == false {
 			t.Fatalf("want: %s, got: %s", "custom_env", out)
@@ -113,7 +113,7 @@ func Test_Invoke_With_CustomEnvVars_AndQueryString(t *testing.T) {
 	})
 
 	t.Run("Populated QueryString", func(t *testing.T) {
-		bytesOut := invoke(t, functionRequest.FunctionName, "testing=1", http.StatusOK)
+		bytesOut := invoke(t, functionRequest.FunctionName, "testing=1", "", http.StatusOK)
 		out := string(bytesOut)
 		if strings.Contains(out, "Http_Query=testing=1") == false {
 			t.Fatalf("want: %s, got: %s", "Http_Query=testing=1", out)

--- a/tests/logs_test.go
+++ b/tests/logs_test.go
@@ -40,8 +40,13 @@ func Test_FunctionLogs(t *testing.T) {
 		copy(cnCases, cases)
 		for index := 0; index < len(cnCases); index++ {
 			ns := config.Namespaces[0]
+
+			newLogs := make([]string, len(cnCases[index].expectedLogs))
+			copy(newLogs, cnCases[index].expectedLogs)
+
+			newLogs[1] = fmt.Sprintf("Wrote %d Bytes", len(ns))
+			cnCases[index].expectedLogs = newLogs
 			cnCases[index].function.Namespace = ns
-			cnCases[index].expectedLogs[1] = fmt.Sprintf("Wrote %d Bytes", len(ns))
 		}
 
 		cases = append(cases, cnCases...)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -45,14 +45,22 @@ func TestMain(m *testing.M) {
 	var err error
 	flag.Parse()
 
+	// get the gateway from the env
 	if config.Gateway == "" {
-		uri, err := url.Parse(os.Getenv("gateway_url"))
-		if err != nil {
-			log.Fatalf("invalid gateway url %s", err)
-		}
-
-		config.Gateway = uri.String()
+		config.Gateway = os.Getenv("gateway_url")
 	}
+
+	// or use the default if it is still empty
+	if config.Gateway == "" {
+		config.Gateway = "http://127.0.0.1:8080/"
+	}
+
+	uri, err := url.Parse(config.Gateway)
+	if err != nil {
+		log.Fatalf("invalid gateway url %s", err)
+	}
+
+	config.Gateway = uri.String()
 
 	// make sure to trim any trailing slash because this is how the gateway is modified when
 	// saved to the config. if we don't do this, we wont find the saved auth.

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -129,12 +129,22 @@ func FromEnv(config *Config) {
 		for index := range config.Namespaces {
 			config.Namespaces[index] = strings.TrimSpace(config.Namespaces[index])
 		}
+
+		// filter empty values from config.Namespaces in place
+		n := 0
+		for _, x := range config.Namespaces {
+			if x != "" {
+				config.Namespaces[n] = x
+				n++
+			}
+		}
+		config.Namespaces = config.Namespaces[:n]
 	}
 
 	// read CERTIFIER_DEFAULT_NAMESPACE variable, if not apply openfaas-fn
 	defaultNamespace, present := os.LookupEnv("CERTIFIER_DEFAULT_NAMESPACE")
 
-	if present {
+	if present && strings.TrimSpace(defaultNamespace) != "" {
 		config.DefaultNamespace = defaultNamespace
 	} else {
 		config.DefaultNamespace = "openfaas-fn"

--- a/tests/scaling_test.go
+++ b/tests/scaling_test.go
@@ -33,7 +33,7 @@ func Test_ScaleMinimum(t *testing.T) {
 		t.Fatalf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
 	}
 
-	defer deleteFunction(t, functionName)
+	defer deleteFunction(t, functionRequest)
 
 	fnc := get(t, functionName)
 	if fnc.Replicas != minReplicas {
@@ -58,7 +58,7 @@ func Test_ScaleFromZeroDuringInvoke(t *testing.T) {
 		t.Fatalf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
 	}
 
-	defer deleteFunction(t, functionName)
+	defer deleteFunction(t, functionRequest)
 
 	scaleFunction(t, functionName, 0)
 
@@ -92,7 +92,7 @@ func Test_ScaleUpAndDownFromThroughPut(t *testing.T) {
 		t.Fatalf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
 	}
 
-	defer deleteFunction(t, functionName)
+	defer deleteFunction(t, functionRequest)
 
 	functionURL := resourceURL(t, path.Join("function", functionName), "")
 	req, err := http.NewRequest(http.MethodPost, functionURL, nil)
@@ -153,7 +153,7 @@ func Test_ScalingDisabledViaLabels(t *testing.T) {
 		t.Fatalf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
 	}
 
-	defer deleteFunction(t, functionName)
+	defer deleteFunction(t, functionRequest)
 
 	functionURL := resourceURL(t, path.Join("function", functionName), "")
 	req, err := http.NewRequest(http.MethodPost, functionURL, nil)
@@ -218,7 +218,7 @@ func Test_ScaleToZero(t *testing.T) {
 		t.Fatalf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
 	}
 
-	defer deleteFunction(t, functionName)
+	defer deleteFunction(t, functionRequest)
 
 	functionURL := resourceURL(t, path.Join("function", functionName), "")
 	req, err := http.NewRequest(http.MethodPost, functionURL, nil)

--- a/tests/scaling_test.go
+++ b/tests/scaling_test.go
@@ -68,7 +68,7 @@ func Test_ScaleFromZeroDuringInvoke(t *testing.T) {
 	}
 
 	// this will fail or pass the test
-	_ = invoke(t, functionName, "", http.StatusOK)
+	_ = invoke(t, functionName, "", "", http.StatusOK)
 }
 
 func Test_ScaleUpAndDownFromThroughPut(t *testing.T) {

--- a/tests/secretCRUD_test.go
+++ b/tests/secretCRUD_test.go
@@ -38,7 +38,7 @@ func Test_SecretCRUD(t *testing.T) {
 	t.Logf("Got correct response for deploying function: %d", deployStatus)
 
 	// Verify that the secret value was set as intended.
-	value := string(invoke(t, functionRequest.FunctionName, "", http.StatusOK))
+	value := string(invoke(t, functionRequest.FunctionName, "", "", http.StatusOK))
 	if value != setValue {
 		t.Errorf("got %s, wanted %s", value, setValue)
 	}
@@ -63,7 +63,7 @@ func Test_SecretCRUD(t *testing.T) {
 		t.Logf("Got correct response for updating secret: %d", updateStatus)
 
 		// Verify that the secret value was edited.
-		value = string(invoke(t, functionRequest.FunctionName, "", http.StatusOK))
+		value = string(invoke(t, functionRequest.FunctionName, "", "", http.StatusOK))
 		if value != setValue {
 			t.Errorf("got %s, wanted %s", value, newValue)
 		}

--- a/tests/strings.go
+++ b/tests/strings.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"math/rand"
+	"strings"
+	"time"
+)
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyz"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+var src = rand.NewSource(time.Now().UnixNano())
+
+func RandString(n int) string {
+	sb := strings.Builder{}
+	sb.Grow(n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			sb.WriteByte(letterBytes[idx])
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return sb.String()
+}


### PR DESCRIPTION
**What**
- Refactor the logs test so that it runs in multiple namespaces, when
  multiple namespaces are configured
- Move the kubernetes cleanup to a scripts to make the implementation in
  bash a little easier
- Remove the swarm targets from the Makefile because the provider has
  been deprecated
- Update the k8s deploy script to enabled multiple namespaces during the
  CI tests
- Update `faas-cli` dependency to `0.13.0`

**Testing**
```sh
kind create cluster

arkade install openfaas --basic-auth=false --clusterrole

kubectl create namespace certifier-test
kubectl annotate namespace/certifier-test openfaas="1"

export CERTIFIER_NAMESPACES=certifier-test

kubectl port-forward -n openfaas svc/gateway 8080:8080 &
make test-kubernetes
```

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>