### PR TITLE
feat: Add multinamespace testing during Secret CRUD

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,8 @@ jobs:
       matrix:
         go-version: [ 1.13.x ]
         os: [ ubuntu-latest ]
+    env:
+      CERTIFIER_NAMESPACES: certifier-test
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,13 @@ TEST_FUNCTIONS = \
 	test-scaling-disabled \
 	test-scaling-to-zero \
 	test-logger \
-	redirector-test
+	redirector-test \
+	secret-string \
+	secret-bytes
 
 TEST_SECRETS = \
-	secret-name
+	secret-string \
+	secret-bytes
 
 export TEST_FUNCTIONS TEST_SECRETS
 
@@ -30,4 +33,4 @@ clean-kubernetes:
 .FEATURE_FLAGS= # set config feature flags, e.g. -swarm
 
 test-kubernetes: clean-kubernetes
-	CERTIFIER_NAMESPACES=certifier-test time go test -count=1 ./tests -v -gateway=${OPENFAAS_URL} ${.FEATURE_FLAGS} ${.TEST_FLAGS}
+	CERTIFIER_NAMESPACES=certifier-test go test -count=1 ./tests -v -gateway=${OPENFAAS_URL} ${.FEATURE_FLAGS} ${.TEST_FLAGS}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/openfaas/faas-cli v0.0.0-20210311204640-2cec97955a25
-	github.com/openfaas/faas-provider v0.17.3
+	github.com/openfaas/faas-provider v0.18.5
 	github.com/rakyll/hey v0.1.4
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gotestyourself/gotestyourself v1.4.0/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
@@ -76,6 +77,8 @@ github.com/openfaas/faas-cli v0.0.0-20210311204640-2cec97955a25/go.mod h1:yw2cWQ
 github.com/openfaas/faas-provider v0.16.1/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
 github.com/openfaas/faas-provider v0.17.3 h1:LN76lrXUKAx27o5X8l+daKWEzsdiW2E99jMOlI1SO5Q=
 github.com/openfaas/faas-provider v0.17.3/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
+github.com/openfaas/faas-provider v0.18.5 h1:y7CCkbh0dW9aWpRisXbjgG9MTZVrdiDKLNt7qqo8M5c=
+github.com/openfaas/faas-provider v0.18.5/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tests/secretCRUD_test.go
+++ b/tests/secretCRUD_test.go
@@ -2,96 +2,189 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	sdk "github.com/openfaas/faas-cli/proxy"
 	"github.com/openfaas/faas-provider/types"
 )
 
-func Test_SecretCRUD(t *testing.T) {
-	setValue := "this-is-the-secret-value"
-	setName := "secret-name"
-	functionName := "test-secret-crud"
+type secretTestCase struct {
+	name         string
+	secret       types.Secret
+	secretUpdate types.Secret
+}
 
+func (t *secretTestCase) SetNamespace(namespace string) {
+	t.name = fmt.Sprintf("%s in %s", t.name, namespace)
+	t.secret.Namespace = namespace
+	t.secretUpdate.Namespace = namespace
+}
+
+func Test_SecretCRUD(t *testing.T) {
 	ctx := context.Background()
 
-	createStatus, _ := config.Client.CreateSecret(ctx, types.Secret{Name: setName, Value: setValue})
-	if createStatus != http.StatusCreated && createStatus != http.StatusAccepted {
-		t.Fatalf("got %d, wanted %d or %d", createStatus, http.StatusOK, http.StatusAccepted)
-	}
-	t.Logf("Got correct response for creating secret: %d", createStatus)
-
-	// Set up and deploy function that reads the value of the created secret.
-	functionRequest := &sdk.DeployFunctionSpec{
-		Image:        "functions/alpine:latest",
-		FunctionName: functionName,
-		Network:      "func_functions",
-		FProcess:     "cat /var/openfaas/secrets/" + setName,
-		Secrets:      []string{setName},
-		Namespace:    config.DefaultNamespace,
-	}
-
-	deployStatus := deploy(t, functionRequest)
-	if deployStatus != http.StatusOK && deployStatus != http.StatusAccepted {
-		t.Errorf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
-	}
-	t.Logf("Got correct response for deploying function: %d", deployStatus)
-
-	// Verify that the secret value was set as intended.
-	value := string(invoke(t, functionRequest, "", "", http.StatusOK))
-	if value != setValue {
-		t.Errorf("got %s, wanted %s", value, setValue)
-	}
-
-	// Verify that the secret can be listed.
-	secrets, err := config.Client.GetSecretList(ctx, config.DefaultNamespace)
-	if err != nil {
-		t.Fatal(err)
+	cases := []secretTestCase{
+		{
+			name: "from string value",
+			secret: types.Secret{
+				Name:      "secret-string",
+				Value:     "this-is-the-secret-string-value",
+				Namespace: config.DefaultNamespace,
+			},
+			secretUpdate: types.Secret{
+				Name:      "secret-string",
+				Value:     "this-is-the-NEW-secret-string-value",
+				Namespace: config.DefaultNamespace,
+			},
+		},
+		{
+			name: "from raw value",
+			secret: types.Secret{
+				Name:      "secret-bytes",
+				RawValue:  []byte("this-is-the-RAW-secret-value"),
+				Namespace: config.DefaultNamespace,
+			},
+			secretUpdate: types.Secret{
+				Name:      "secret-bytes",
+				RawValue:  []byte("this-is-the-NEW-RAW-secret-value"),
+				Namespace: config.DefaultNamespace,
+			},
+		},
 	}
 
-	if !listContains(secrets, setName) {
-		t.Errorf("got %v, wanted %s in slice", secrets, setName)
-	}
-
-	// Docker Swarm secrets are immutable, so skip the update tests for swarm.
-	if config.SecretUpdate {
-		newValue := "this-is-the-edited-secret-value"
-		updateStatus, _ := config.Client.UpdateSecret(ctx, types.Secret{Name: setName, Value: newValue})
-		if updateStatus != http.StatusOK && updateStatus != http.StatusAccepted {
-			t.Errorf("got %d, wanted %d or %d", updateStatus, http.StatusOK, http.StatusAccepted)
+	if len(config.Namespaces) > 0 {
+		defaultCasesLen := len(cases)
+		for index := 0; index < defaultCasesLen; index++ {
+			namespacedCase := cases[index]
+			namespacedCase.SetNamespace(config.Namespaces[0])
+			cases = append(cases, namespacedCase)
 		}
-		t.Logf("Got correct response for updating secret: %d", updateStatus)
-
-		// Verify that the secret value was edited.
-		value = string(invoke(t, functionRequest, "", "", http.StatusOK))
-		if value != setValue {
-			t.Errorf("got %s, wanted %s", value, newValue)
-		}
-	} else {
-		t.Log("secret update skipped")
 	}
 
-	// Function needs to be deleted to free up the secret so it can also be deleted.
-	err = config.Client.DeleteFunction(ctx, functionRequest.FunctionName, functionRequest.Namespace)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("Got correct response for deleting function")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			functionName := tc.secret.Name
+			value := tc.secret.Value
+			if tc.secret.Value == "" {
+				value = string(tc.secret.RawValue)
+			}
 
-	err = config.Client.RemoveSecret(ctx, types.Secret{Name: setName})
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("Got correct response for deleting secret:")
+			// Verify that the secret are empty.
+			secrets, err := config.Client.GetSecretList(ctx, tc.secret.Namespace)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	// Verify that the secret was deleted.
-	secrets, err = config.Client.GetSecretList(ctx, config.DefaultNamespace)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if listContains(secrets, setName) {
-		t.Errorf("got %v, wanted %s deleted", secrets, setName)
+			if listContains(secrets, tc.secret.Name) {
+				t.Fatalf("namespace already has secret %s in %s: %v", tc.secret.Name, tc.secret.Namespace, secrets)
+			}
+
+			t.Logf("existing secrets in %s: %v", tc.secret.Namespace, secrets)
+
+			// Set up and deploy function that reads the value of the created secret.
+			functionRequest := &sdk.DeployFunctionSpec{
+				Image:        "functions/alpine:latest",
+				FunctionName: functionName,
+				Network:      "func_functions",
+				FProcess:     "cat /var/openfaas/secrets/" + tc.secret.Name,
+				Secrets:      []string{tc.secret.Name},
+				Namespace:    tc.secret.Namespace,
+				Annotations:  map[string]string{},
+			}
+
+			t.Run("create", func(t *testing.T) {
+				createStatus, _ := config.Client.CreateSecret(ctx, tc.secret)
+				if createStatus != http.StatusCreated && createStatus != http.StatusAccepted {
+					t.Fatalf("got %d, wanted %d or %d", createStatus, http.StatusOK, http.StatusAccepted)
+				}
+
+				deployStatus := deploy(t, functionRequest)
+				if deployStatus != http.StatusOK && deployStatus != http.StatusAccepted {
+					t.Errorf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
+				}
+
+				// Verify that the secret value was set as intended.
+				mountedValue := string(invoke(t, functionRequest, "", "", http.StatusOK))
+				if mountedValue != value {
+					t.Errorf("got %s, wanted %s", value, value)
+				}
+			})
+
+			t.Run("list", func(t *testing.T) {
+				// Verify that the secret can be listed.
+				secrets, err := config.Client.GetSecretList(ctx, tc.secret.Namespace)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !listContains(secrets, tc.secret.Name) {
+					t.Errorf("got %v, wanted %s in slice", secrets, tc.secret.Name)
+				}
+			})
+
+			t.Run("update", func(t *testing.T) {
+				if !config.SecretUpdate {
+					// Docker Swarm secrets are immutable, so skip the update tests for swarm.
+					t.Skip("secret update not enabled")
+					return
+				}
+
+				value := tc.secretUpdate.Value
+				if tc.secretUpdate.Value == "" {
+					value = string(tc.secretUpdate.RawValue)
+				}
+
+				updateStatus, _ := config.Client.UpdateSecret(ctx, tc.secretUpdate)
+				if updateStatus != http.StatusOK && updateStatus != http.StatusAccepted {
+					t.Errorf("got %d, wanted %d or %d", updateStatus, http.StatusOK, http.StatusAccepted)
+				}
+
+				// let the cluster stabilize
+				time.Sleep(time.Second)
+
+				functionRequest.Update = true
+				functionRequest.Annotations["secret-hash"] = "something to convince orchestrators that the deployment has changed"
+				deployStatus := deploy(t, functionRequest)
+				if deployStatus != http.StatusOK && deployStatus != http.StatusAccepted {
+					t.Errorf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
+				}
+
+				// let the cluster stabilize
+				time.Sleep(5 * time.Second)
+
+				// Verify that the secret value was updated and mounted
+				mountedValue := string(invoke(t, functionRequest, "", "", http.StatusOK))
+				if mountedValue != value {
+					t.Errorf("got %s, wanted %s", mountedValue, value)
+				}
+			})
+
+			t.Run("delete", func(t *testing.T) {
+				// Function needs to be deleted to free up the secret so it can also be deleted.
+				err := config.Client.DeleteFunction(ctx, functionRequest.FunctionName, functionRequest.Namespace)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = config.Client.RemoveSecret(ctx, tc.secret)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Verify that the secret was deleted.
+				secrets, err := config.Client.GetSecretList(ctx, tc.secret.Namespace)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if listContains(secrets, tc.secret.Name) {
+					t.Errorf("got %v, wanted %s deleted", secrets, tc.secret.Name)
+				}
+			})
+		})
 	}
 }
 


### PR DESCRIPTION
- Add multinamespace configuration to the secrets, refactoring to use a
  test table.
- Update to the latest faas-provider
- Add test for raw value support

**Notes**
- the new RawValue support in faas-netes is broken, it does not support Update yet


**Testing**

```sh
kind create cluster

arkade install openfaas --basic-auth=false --clusterrole

kubectl create namespace certifier-test
kubectl annotate namespace/certifier-test openfaas="1"

export CERTIFIER_NAMESPACES=certifier-test

kubectl port-forward -n openfaas svc/gateway 8080:8080 &
make test-kubernetes
```

Resolves #67 
