### PR TITLE
feat: Add multi-namespace test for scaling

### DIFF
--- a/tests/function_helpers_test.go
+++ b/tests/function_helpers_test.go
@@ -68,14 +68,13 @@ func deleteFunction(t *testing.T, function *sdk.DeployFunctionSpec) {
 	}
 }
 
-func scaleFunction(t *testing.T, name string, count int) {
+func scaleFunction(t *testing.T, name, namespace string, count int) {
 	t.Helper()
 
 	// the CLI sdk does not currently support manually scaling
-	gwURL := resourceURL(t, path.Join("system", "scale-function", name), "")
+	gwURL := resourceURL(t, path.Join("system", "scale-function", name), fmt.Sprintf("namespace=%s", namespace))
 	payload := makeReader(map[string]interface{}{"service": name, "replicas": count})
 
-	// TODO : enable auth
 	_, res := request(t, gwURL, http.MethodPost, config.Auth, payload)
 	if res.StatusCode != http.StatusAccepted && res.StatusCode != http.StatusOK {
 		t.Fatalf("scale got %d, wanted %d (or %d)", res.StatusCode, http.StatusAccepted, http.StatusOK)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -108,6 +109,8 @@ type Config struct {
 	// AuthEnabled
 	AuthEnabled bool
 
+	IdlerEnabled bool
+
 	// SecretUpdate enables/disables the secret update test
 	SecretUpdate bool
 	// ScaleToZero enables/disables the scale from zero test
@@ -147,5 +150,15 @@ func FromEnv(config *Config) {
 		config.DefaultNamespace = defaultNamespace
 	} else {
 		config.DefaultNamespace = "openfaas-fn"
+	}
+
+	idlerEnabled, ok := os.LookupEnv("idler_enabled")
+	if ok && idlerEnabled == "true" {
+		enableTest, err := strconv.ParseBool(idlerEnabled)
+		if err != nil {
+			log.Fatalf("can parse idler_enabled env flag: %s", err.Error())
+		}
+
+		config.IdlerEnabled = enableTest
 	}
 }


### PR DESCRIPTION
Rewrite the scaling tests into a table driven test and add support to
running in multiple namespaces.

**Testing**

```sh
kind create cluster

arkade install openfaas --basic-auth=false --clusterrole

kubectl create namespace certifier-test
kubectl annotate namespace/certifier-test openfaas="1"

export CERTIFIER_NAMESPACES=certifier-test

kubectl port-forward -n openfaas svc/gateway 8080:8080 &
make test-kubernetes
```

Resolves #70