### PR TITLE
feat: add multi-namespace testing for secrets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ on:
 
 env:
   IP: 127.0.0.1
+  CERTIFIER_NAMESPACES: certifier-test
 
 jobs:
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ "*" ]
+    branches: ["*"]
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
 
 env:
   IP: 127.0.0.1
@@ -14,8 +14,8 @@ jobs:
   lint:
     strategy:
       matrix:
-        go-version: [ 1.13.x ]
-        os: [ ubuntu-latest ]
+        go-version: [1.13.x]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
@@ -32,8 +32,8 @@ jobs:
   test-kubernetes:
     strategy:
       matrix:
-        go-version: [ 1.13.x ]
-        os: [ ubuntu-latest ]
+        go-version: [1.13.x]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
@@ -56,9 +56,11 @@ jobs:
   test-faasd:
     strategy:
       matrix:
-        go-version: [ 1.13.x ]
-        os: [ ubuntu-latest ]
+        go-version: [1.13.x]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      CERTIFIER_NAMESPACES: ""
     steps:
       - uses: actions/checkout@master
         with:

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,4 @@ test-kubernetes: clean-kubernetes
 	CERTIFIER_NAMESPACES=certifier-test time go test -p=1 -count=1 ./tests -v -gateway=${OPENFAAS_URL} ${.FEATURE_FLAGS} ${.TEST_FLAGS}
 
 test-faasd: clean-faasd
-	CERTIFIER_NAMESPACES=certifier-test time go test -p=1 -count=1 ./tests -v -gateway=${OPENFAAS_URL} -enableAuth ${.FEATURE_FLAGS} ${.TEST_FLAGS}
+	time go test -p=1 -count=1 ./tests -v -gateway=${OPENFAAS_URL} -enableAuth ${.FEATURE_FLAGS} ${.TEST_FLAGS}

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,13 @@ TEST_FUNCTIONS = \
 	test-scaling-disabled \
 	test-scaling-to-zero \
 	test-logger \
-	redirector-test
+	redirector-test \
+	secret-string \
+	secret-bytes
 
 TEST_SECRETS = \
-	secret-name
+	secret-string \
+	secret-bytes
 
 export TEST_FUNCTIONS TEST_SECRETS
 

--- a/contrib/deploy_faasd.sh
+++ b/contrib/deploy_faasd.sh
@@ -5,8 +5,10 @@ sudo curl -s https://raw.githubusercontent.com/openfaas/faasd/master/hack/instal
 
 sleep 120
 
-sudo ctr namespace create certifier-test
-sudo ctr namespace label certifier-test openfaas=true
+if [ "z$CERTIFIER_NAMESPACES" != "z" ]; then
+    sudo ctr namespace create certifier-test
+    sudo ctr namespace label certifier-test openfaas=true
+fi
 
 echo ">>> Login Using faas-cli"
 cd $HOME

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.13
 
 require (
 	github.com/openfaas/faas-cli v0.0.0-20210311204640-2cec97955a25
-	github.com/openfaas/faas-provider v0.17.3
+	github.com/openfaas/faas-provider v0.18.6
 	github.com/rakyll/hey v0.1.4
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gotestyourself/gotestyourself v1.4.0/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
@@ -76,6 +77,8 @@ github.com/openfaas/faas-cli v0.0.0-20210311204640-2cec97955a25/go.mod h1:yw2cWQ
 github.com/openfaas/faas-provider v0.16.1/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
 github.com/openfaas/faas-provider v0.17.3 h1:LN76lrXUKAx27o5X8l+daKWEzsdiW2E99jMOlI1SO5Q=
 github.com/openfaas/faas-provider v0.17.3/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
+github.com/openfaas/faas-provider v0.18.6 h1:wypzvPKZqta8t4rx3W6Dm14ommBCc+rQ4DKDiBdGB7M=
+github.com/openfaas/faas-provider v0.18.6/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tests/logs_test.go
+++ b/tests/logs_test.go
@@ -72,6 +72,11 @@ func Test_FunctionLogs(t *testing.T) {
 				ns = config.DefaultNamespace
 			}
 
+			err := waitForFunctionStatus(time.Minute, c.function.FunctionName, ns, minAvailableReplicaCount(1))
+			if err != nil {
+				t.Fatalf("Function %q failed to start: %s", c.function.FunctionName, err)
+			}
+
 			data := invoke(t, &c.function, "", ns, http.StatusOK)
 			if string(data) != ns {
 				t.Fatalf("got invoke response %s, expected %s", string(data), ns)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 var (
-	config                = Config{}
-	token                 = flag.String("token", "", "authentication Bearer token override, enables auth automatically")
-	faasdProviderName     = "faasd"
-	faasNetesProviderName = "faas-netes"
+	config            = Config{}
+	token             = flag.String("token", "", "authentication Bearer token override, enables auth automatically")
+	faasdProviderName = "faasd"
+	// faasNetesProviderName = "faas-netes"
 )
 
 func init() {

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -90,6 +90,7 @@ func TestMain(m *testing.M) {
 
 	if config.ProviderName == faasdProviderName {
 		config.EnableScaling = false
+		config.SecretUpdate = false
 	}
 
 	prettyConfig, err := json.MarshalIndent(config, "", "\t")

--- a/tests/secretCRUD_test.go
+++ b/tests/secretCRUD_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -10,99 +11,183 @@ import (
 	"github.com/openfaas/faas-provider/types"
 )
 
-func Test_SecretCRUD(t *testing.T) {
-	setValue := "this-is-the-secret-value"
-	setName := "secret-name"
-	functionName := "test-secret-crud"
+type secretTestCase struct {
+	name         string
+	secret       types.Secret
+	secretUpdate types.Secret
+}
 
+func (t *secretTestCase) SetNamespace(namespace string) {
+	t.name = fmt.Sprintf("%s in %s", t.name, namespace)
+	t.secret.Namespace = namespace
+	t.secretUpdate.Namespace = namespace
+}
+
+func Test_SecretCRUD(t *testing.T) {
 	ctx := context.Background()
 
-	createStatus, _ := config.Client.CreateSecret(ctx, types.Secret{Name: setName, Value: setValue})
-	if createStatus != http.StatusOK && createStatus != http.StatusAccepted {
-		t.Fatalf("got %d, wanted %d or %d", createStatus, http.StatusOK, http.StatusAccepted)
-	}
-	t.Logf("Got correct response for creating secret: %d", createStatus)
-
-	// Set up and deploy function that reads the value of the created secret.
-	functionRequest := &sdk.DeployFunctionSpec{
-		Image:        "functions/alpine:latest",
-		FunctionName: functionName,
-		Network:      "func_functions",
-		FProcess:     "cat /var/openfaas/secrets/" + setName,
-		Secrets:      []string{setName},
-		Namespace:    config.DefaultNamespace,
-	}
-
-	deployStatus := deploy(t, functionRequest)
-	if deployStatus != http.StatusOK && deployStatus != http.StatusAccepted {
-		t.Errorf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
-	}
-	t.Logf("Got correct response for deploying function: %d", deployStatus)
-
-	// Verify that the secret value was set as intended.
-	value := string(invoke(t, functionRequest, "", "", http.StatusOK))
-	if value != setValue {
-		t.Errorf("got %s, wanted %s", value, setValue)
-	}
-
-	// Verify that the secret can be listed.
-	secrets, err := config.Client.GetSecretList(ctx, config.DefaultNamespace)
-	if err != nil {
-		t.Fatal(err)
+	cases := []secretTestCase{
+		{
+			name: "from string value",
+			secret: types.Secret{
+				Name:      "secret-string",
+				Value:     "this-is-the-secret-string-value",
+				Namespace: config.DefaultNamespace,
+			},
+			secretUpdate: types.Secret{
+				Name:      "secret-string",
+				Value:     "this-is-the-NEW-secret-string-value",
+				Namespace: config.DefaultNamespace,
+			},
+		},
+		{
+			name: "from raw value",
+			secret: types.Secret{
+				Name:      "secret-bytes",
+				RawValue:  []byte("this-is-the-RAW-secret-value"),
+				Namespace: config.DefaultNamespace,
+			},
+			secretUpdate: types.Secret{
+				Name:      "secret-bytes",
+				RawValue:  []byte("this-is-the-NEW-RAW-secret-value"),
+				Namespace: config.DefaultNamespace,
+			},
+		},
 	}
 
-	if !listContains(secrets, setName) {
-		t.Errorf("got %v, wanted %s in slice", secrets, setName)
-	}
-
-	newValue := "this-is-the-edited-secret-value"
-	updateStatus, _ := config.Client.UpdateSecret(ctx, types.Secret{Name: setName, Value: newValue})
-	if updateStatus != http.StatusOK && updateStatus != http.StatusAccepted {
-		t.Errorf("got %d, wanted %d or %d", updateStatus, http.StatusOK, http.StatusAccepted)
-	}
-	t.Logf("Got correct response for updating secret: %d", updateStatus)
-
-	if config.ProviderName == faasNetesProviderName {
-		err = config.Client.ScaleFunction(ctx, functionName, config.DefaultNamespace, 0)
-		if err != nil {
-			t.Error("Scaling down function to zero failed!")
+	if len(config.Namespaces) > 0 {
+		defaultCasesLen := len(cases)
+		for index := 0; index < defaultCasesLen; index++ {
+			namespacedCase := cases[index]
+			namespacedCase.SetNamespace(config.Namespaces[0])
+			cases = append(cases, namespacedCase)
 		}
-		t.Log("Scale Down function to zero")
-		time.Sleep(time.Minute)
-		err = config.Client.ScaleFunction(ctx, functionName, config.DefaultNamespace, 1)
-		if err != nil {
-			t.Error("Scaling up function from zero failed!")
-		}
-		t.Log("Scale up function from zero")
-		time.Sleep(time.Minute)
 	}
 
-	// Verify that the secret value was edited.
-	value = string(invoke(t, functionRequest, "", "", http.StatusOK))
-	if value != newValue {
-		t.Errorf("got %s, wanted %s", value, newValue)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			functionName := tc.secret.Name
+			value := tc.secret.Value
+			if tc.secret.Value == "" {
+				value = string(tc.secret.RawValue)
+			}
 
-	// Function needs to be deleted to free up the secret so it can also be deleted.
-	err = config.Client.DeleteFunction(ctx, functionRequest.FunctionName, functionRequest.Namespace)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("Got correct response for deleting function")
+			// Verify that the secret are empty.
+			secrets, err := config.Client.GetSecretList(ctx, tc.secret.Namespace)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	err = config.Client.RemoveSecret(ctx, types.Secret{Name: setName})
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("Got correct response for deleting secret:")
+			if listContains(secrets, tc.secret.Name) {
+				t.Fatalf("namespace already has secret %s in %s: %v", tc.secret.Name, tc.secret.Namespace, secrets)
+			}
 
-	// Verify that the secret was deleted.
-	secrets, err = config.Client.GetSecretList(ctx, config.DefaultNamespace)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if listContains(secrets, setName) {
-		t.Errorf("got %v, wanted %s deleted", secrets, setName)
+			t.Logf("existing secrets in %s: %v", tc.secret.Namespace, secrets)
+
+			// Set up and deploy function that reads the value of the created secret.
+			functionRequest := &sdk.DeployFunctionSpec{
+				Image:        "functions/alpine:latest",
+				FunctionName: functionName,
+				Network:      "func_functions",
+				FProcess:     "cat /var/openfaas/secrets/" + tc.secret.Name,
+				Secrets:      []string{tc.secret.Name},
+				Namespace:    tc.secret.Namespace,
+				Annotations:  map[string]string{},
+			}
+
+			t.Run("create", func(t *testing.T) {
+				createStatus, _ := config.Client.CreateSecret(ctx, tc.secret)
+				switch createStatus {
+				case http.StatusCreated, http.StatusAccepted, http.StatusOK:
+					// happy path
+				default:
+					t.Fatalf("got %d, wanted %d or %d", createStatus, http.StatusOK, http.StatusAccepted)
+				}
+
+				deployStatus := deploy(t, functionRequest)
+				if deployStatus != http.StatusOK && deployStatus != http.StatusAccepted {
+					t.Errorf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
+				}
+
+				// Verify that the secret value was set as intended.
+				mountedValue := string(invoke(t, functionRequest, "", "", http.StatusOK))
+				if mountedValue != value {
+					t.Errorf("got %s, wanted %s", value, value)
+				}
+			})
+
+			t.Run("list", func(t *testing.T) {
+				// Verify that the secret can be listed.
+				secrets, err := config.Client.GetSecretList(ctx, tc.secret.Namespace)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !listContains(secrets, tc.secret.Name) {
+					t.Errorf("got %v, wanted %s in slice", secrets, tc.secret.Name)
+				}
+			})
+
+			t.Run("update", func(t *testing.T) {
+				if !config.SecretUpdate {
+					// Docker Swarm secrets are immutable, so skip the update tests for swarm.
+					t.Skip("secret update not enabled")
+					return
+				}
+
+				value := tc.secretUpdate.Value
+				if tc.secretUpdate.Value == "" {
+					value = string(tc.secretUpdate.RawValue)
+				}
+
+				updateStatus, _ := config.Client.UpdateSecret(ctx, tc.secretUpdate)
+				if updateStatus != http.StatusOK && updateStatus != http.StatusAccepted {
+					t.Errorf("got %d, wanted %d or %d", updateStatus, http.StatusOK, http.StatusAccepted)
+				}
+
+				// let the cluster stabilize
+				time.Sleep(time.Second)
+
+				functionRequest.Update = true
+				functionRequest.Annotations["secret-hash"] = "something to convince orchestrators that the deployment has changed"
+				deployStatus := deploy(t, functionRequest)
+				if deployStatus != http.StatusOK && deployStatus != http.StatusAccepted {
+					t.Errorf("got %d, wanted %d or %d", deployStatus, http.StatusOK, http.StatusAccepted)
+				}
+
+				// let the cluster stabilize
+				time.Sleep(5 * time.Second)
+
+				// Verify that the secret value was updated and mounted
+				mountedValue := string(invoke(t, functionRequest, "", "", http.StatusOK))
+				if mountedValue != value {
+					t.Errorf("got %s, wanted %s", mountedValue, value)
+				}
+			})
+
+			t.Run("delete", func(t *testing.T) {
+				// Function needs to be deleted to free up the secret so it can also be deleted.
+				err := config.Client.DeleteFunction(ctx, functionRequest.FunctionName, functionRequest.Namespace)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = config.Client.RemoveSecret(ctx, tc.secret)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Verify that the secret was deleted.
+				secrets, err := config.Client.GetSecretList(ctx, tc.secret.Namespace)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if listContains(secrets, tc.secret.Name) {
+					t.Errorf("got %v, wanted %s deleted", secrets, tc.secret.Name)
+				}
+			})
+		})
 	}
 }
 

--- a/tests/secretCRUD_test.go
+++ b/tests/secretCRUD_test.go
@@ -112,7 +112,7 @@ func Test_SecretCRUD(t *testing.T) {
 				// Verify that the secret value was set as intended.
 				mountedValue := string(invoke(t, functionRequest, "", "", http.StatusOK))
 				if mountedValue != value {
-					t.Errorf("got %s, wanted %s", value, value)
+					t.Errorf("got %s, wanted %s", mountedValue, value)
 				}
 			})
 


### PR DESCRIPTION
- Add multinamespace configuration to the secrets, refactoring to use a
  test table.
- Update to the latest faas-provider
- Add test for raw value support

**Notes**
- the new RawValue support in faas-netes is broken, it does not support Update yet

**Testing**

```sh
kind create cluster

arkade install openfaas --basic-auth=false --clusterrole

kubectl create namespace certifier-test
kubectl annotate namespace/certifier-test openfaas="1"

export CERTIFIER_NAMESPACES=certifier-test

kubectl port-forward -n openfaas svc/gateway 8080:8080 &
make test-kubernetes
```

Resolves #67
Closes #74

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>