### PR TITLE
remove faas-swarm references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean-faasd:
 	- ./contrib/clean_faasd.sh
 
 .TEST_FLAGS= # additional test flags, e.g. -run ^Test_ScaleFromZeroDuringIvoke$
-.FEATURE_FLAGS= # set config feature flags, e.g. -swarm
+.FEATURE_FLAGS= # set config feature flags, e.g. -enableScaling, -secretUpdate
 
 test-kubernetes: clean-kubernetes
 	CERTIFIER_NAMESPACES=certifier-test time go test -p=1 -count=1 ./tests -v -gateway=${OPENFAAS_URL} ${.FEATURE_FLAGS} ${.TEST_FLAGS}

--- a/README.md
+++ b/README.md
@@ -35,17 +35,6 @@ export OPENFAAS_URL=http://127.0.0.1:31112/
 make test-kubernetes .FEATURE_FLAGS='-enableAuth'
 ```
 
-### Swarm
-
-Usage with gateway on `http://127.0.0.1:8080/`:
-
-```
-export OPENFAAS_URL=http://127.0.0.1:8080/
-make test-swarm
-```
-
-You will need to have access to `docker` for creating and cleaning-up of state.
-
 ## Development
 
 While developing the `certifier`, we generally run/test the `certifier` locally using `faas-netes`.  The cleanest way to do this is using an throw-away cluster using [KinD](https://github.com/kubernetes-sigs/kind) and [arkade](https://github.com/alexellis/arkade)
@@ -91,12 +80,10 @@ Some providers may not implement all features (yet) or an installation may have 
     	enable/disable authentication. The auth will be parsed from the default config in ~/.openfaas/config.yml
   -gateway string
     	set the gateway URL, if empty use the gateway_url env variable
-  -scaleToZero
+  -enableScaling
     	enable/disable scale from zero tests (default true)
   -secretUpdate
     	enable/disable secret update tests (default true)
-  -swarm
-    	helper flag to run only swarm-compatible tests only
   -token string
     	authentication Bearer token override, enables auth automatically
 ```

--- a/contrib/clean_swarm_cluster.sh
+++ b/contrib/clean_swarm_cluster.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-echo ">>> Leaving Swarm cluster"
-
-docker swarm leave --force

--- a/contrib/create_swarm_cluster.sh
+++ b/contrib/create_swarm_cluster.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-echo ">>> Creating Swarm cluster"
-
-docker swarm init

--- a/contrib/deploy_stack.sh
+++ b/contrib/deploy_stack.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-echo ">>> Cloning the faas project"
-git clone https://github.com/openfaas/faas.git
-
-echo ">>> Deploying the stack"
-cd faas && echo "$(pwd)" && ./deploy_stack.sh --no-auth && cd ..

--- a/tests/deploy_test.go
+++ b/tests/deploy_test.go
@@ -250,7 +250,7 @@ func compareDeployAndStatus(deploy types.FunctionDeployment, status types.Functi
 }
 
 func strMapEqual(mapName string, got map[string]string, wanted map[string]string) error {
-	// Can't assert length is equal as some providers i.e. faas-swarm add their own labels during
+	// Can't assert length is equal as some providers add their own labels during
 	// deployment like 'com.openfaas.function' and 'function'
 
 	for k, v := range wanted {


### PR DESCRIPTION
This commit removes faas-swarm references and support from this repo as faas-swarm has been
deprecated.

fixes: #76
Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>